### PR TITLE
Use ClientTrace instead of manually creating a connection

### DIFF
--- a/main.go
+++ b/main.go
@@ -218,11 +218,9 @@ func visit(url *url.URL) {
 		log.Fatalf("failed to read response: %v", err)
 	}
 
-	t5 := time.Now() // after read response
 	bodyMsg := readResponseBody(req, resp)
-	resp.Body.Close()
 
-	t6 := time.Now() // after read body
+	t5 := time.Now() // after read body
 
 	// print status line and headers
 	printf("\n%s%s%s\n", color.GreenString("HTTP"), grayscale(14)("/"), color.CyanString("%d.%d %s", resp.ProtoMajor, resp.ProtoMinor, resp.Status))
@@ -262,24 +260,24 @@ func visit(url *url.URL) {
 			fmta(t1.Sub(t0)), // dns lookup
 			fmta(t2.Sub(t1)), // tcp connection
 			fmta(t3.Sub(t2)), // tls handshake
-			fmta(t5.Sub(t4)), // server processing
-			fmta(t6.Sub(t5)), // content transfer
+			fmta(t4.Sub(t3)), // server processing
+			fmta(t5.Sub(t4)), // content transfer
 			fmtb(t1.Sub(t0)), // namelookup
 			fmtb(t2.Sub(t0)), // connect
 			fmtb(t3.Sub(t0)), // pretransfer
-			fmtb(t5.Sub(t0)), // starttransfer
-			fmtb(t6.Sub(t0)), // total
+			fmtb(t4.Sub(t0)), // starttransfer
+			fmtb(t5.Sub(t0)), // total
 		)
 	case "http":
 		printf(colorize(HTTPTemplate),
 			fmta(t1.Sub(t0)), // dns lookup
 			fmta(t3.Sub(t1)), // tcp connection
-			fmta(t5.Sub(t3)), // server processing
-			fmta(t6.Sub(t5)), // content transfer
+			fmta(t4.Sub(t3)), // server processing
+			fmta(t5.Sub(t4)), // content transfer
 			fmtb(t1.Sub(t0)), // namelookup
 			fmtb(t3.Sub(t0)), // connect
-			fmtb(t5.Sub(t0)), // starttransfer
-			fmtb(t6.Sub(t0)), // total
+			fmtb(t4.Sub(t0)), // starttransfer
+			fmtb(t5.Sub(t0)), // total
 		)
 	}
 

--- a/main.go
+++ b/main.go
@@ -172,7 +172,7 @@ func getHostPort(url *url.URL) (string, string, string) {
 // visit visits a url and times the interaction.
 // If the response is a 30x, visit follows the redirect.
 func visit(url *url.URL) {
-	scheme, host, port := getHostPort(url)
+	scheme, host, _ := getHostPort(url)
 
 	host, _, err := net.SplitHostPort(url.Host)
 	if err != nil {
@@ -216,10 +216,10 @@ func visit(url *url.URL) {
 	req = req.WithContext(httptrace.WithClientTrace(context.Background(), trace))
 
 	tr := &http.Transport{}
-	if insecure {
+	if scheme == "https" {
 		tr.TLSClientConfig = &tls.Config{
 			ServerName:         host,
-			InsecureSkipVerify: true,
+			InsecureSkipVerify: insecure,
 		}
 	}
 

--- a/main.go
+++ b/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"crypto/tls"
 	"flag"
 	"fmt"
 	"io"
@@ -212,7 +213,14 @@ func visit(url *url.URL) {
 
 	req = req.WithContext(httptrace.WithClientTrace(context.Background(), trace))
 
-	resp, err := http.DefaultClient.Do(req)
+	tr := &http.Transport{}
+	if insecure {
+		tr.TLSClientConfig = &tls.Config{InsecureSkipVerify: true}
+	}
+
+	client := &http.Client{Transport: tr}
+
+	resp, err := client.Do(req)
 
 	if err != nil {
 		log.Fatalf("failed to read response: %v", err)

--- a/main.go
+++ b/main.go
@@ -20,6 +20,7 @@ import (
 	"time"
 
 	"github.com/fatih/color"
+	"net"
 )
 
 const (
@@ -173,6 +174,11 @@ func getHostPort(url *url.URL) (string, string, string) {
 func visit(url *url.URL) {
 	scheme, host, port := getHostPort(url)
 
+	host, _, err := net.SplitHostPort(url.Host)
+	if err != nil {
+		host = url.Host
+	}
+
 	var t0, t1, t2, t3, t4 time.Time
 
 	trace := &httptrace.ClientTrace{
@@ -215,7 +221,10 @@ func visit(url *url.URL) {
 
 	tr := &http.Transport{}
 	if insecure {
-		tr.TLSClientConfig = &tls.Config{InsecureSkipVerify: true}
+		tr.TLSClientConfig = &tls.Config{
+			ServerName:         host,
+			InsecureSkipVerify: true,
+		}
 	}
 
 	client := &http.Client{Transport: tr}

--- a/main.go
+++ b/main.go
@@ -200,10 +200,6 @@ func visit(url *url.URL) {
 		httpMethod = "HEAD"
 	}
 
-	if (httpMethod == "POST" || httpMethod == "PUT") && postBody == "" {
-		log.Fatal("must supply post body using -d when POST or PUT is used")
-	}
-
 	req, err := http.NewRequest(httpMethod, url.String(), createBody(postBody))
 	if err != nil {
 		log.Fatalf("unable to create request: %v", err)


### PR DESCRIPTION
This pull request refactors the code to use the [`net/http/httptrace`](https://golang.org/pkg/net/http/httptrace/) package instead of manually resolving DNS and opening a connection.