### PR TITLE
Sort headers

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ The big ticket features which are missing at this point are:
 - ~~detect when `httpstat` is being piped to a file or other not tty device and disable coloured output.~~ done, thanks @amy
 - support for more CURL flags, like `-H HEADER` and `-X METHOD`.
 - spool response.Body to a temporary file.
-- Sort response headers intelligently, #18.
+- ~~Sort response headers intelligently, #18.~~
 - ~~Support curl's `-L` flag to follow redirects, #23.~~
 - Handle urls without a scheme, #26
 


### PR DESCRIPTION
Fixes #18
Closes #16 

Sort headers in a (roughly) stable manner. Server comes first, then the
end to end headers, then the hop by hop headers, each sorted
alphabetically.