### PR TITLE
Better url handling

### DIFF
--- a/main.go
+++ b/main.go
@@ -95,12 +95,11 @@ func main() {
 // If the scheme is missing, we assume it's "https" (or "http" if port 80).
 // If the host is missing, we assume it's "localhost".
 func normalizeURL(rawURL string) string {
-	if strings.Index(rawURL, "://") > -1 {
+	if strings.Contains(rawURL, "://") {
 		return rawURL
 	}
 
-	hostport := strings.Split(rawURL, ":")
-	if len(hostport) == 2 {
+	if hostport := strings.Split(rawURL, ":"); len(hostport) == 2 {
 		if hostport[0] == "" {
 			rawURL = "localhost:" + hostport[1]
 		}

--- a/main.go
+++ b/main.go
@@ -148,7 +148,7 @@ func visit(url *url.URL) {
 	t1 := time.Now() // after dns resolution, before connect
 	conn, err = net.DialTCP("tcp", nil, raddr)
 	if err != nil {
-		log.Fatalf("unable to connect to host %vv %v", raddr, err)
+		log.Fatalf("unable to connect to host %v %v", raddr, err)
 	}
 
 	var t2 time.Time // after connect, before TLS handshake

--- a/main.go
+++ b/main.go
@@ -82,12 +82,35 @@ func main() {
 		log.Fatalf(usage)
 	}
 
-	url, err := url.Parse(args[0])
+	rawURL := normalizeURL(args[0])
+	url, err := url.Parse(rawURL)
 	if err != nil {
 		log.Fatalf("could not parse url %q: %v", args[0], err)
 	}
 
 	visit(url)
+}
+
+// normalizeURL normalizes the url input.
+// If the scheme is missing, we assume it's "https" (or "http" if port 80).
+// If the host is missing, we assume it's "localhost".
+func normalizeURL(rawURL string) string {
+	if strings.Index(rawURL, "://") > -1 {
+		return rawURL
+	}
+
+	hostport := strings.Split(rawURL, ":")
+	if len(hostport) == 2 {
+		if hostport[0] == "" {
+			rawURL = "localhost:" + hostport[1]
+		}
+
+		if strings.Index(hostport[1], "80") == 0 {
+			return "http://" + rawURL
+		}
+	}
+
+	return "https://" + rawURL
 }
 
 // visit visits a url and times the interaction.


### PR DESCRIPTION
These cases should work:

```
httpstat google.com
httpstat google.com:443
httpstat google.com:80
httpstat :80/test # becomes: http://localhost/test
httpstat :9000/test # becomes: https://localhost:9000/test
```