### PR TITLE
HTTPS default secure but allow insecure when flag provided

### DIFF
--- a/main.go
+++ b/main.go
@@ -58,6 +58,7 @@ var (
 	postBody        string
 	followRedirects bool
 	onlyHeader      bool
+	insecure        bool
 
 	usage = fmt.Sprintf("usage: %s URL", os.Args[0])
 )
@@ -67,6 +68,8 @@ func init() {
 	flag.StringVar(&postBody, "d", "", "the body of a POST or PUT request")
 	flag.BoolVar(&followRedirects, "L", false, "follow 30x redirects")
 	flag.BoolVar(&onlyHeader, "I", false, "don't read body of request")
+	flag.BoolVar(&insecure, "k", false, "allow insecure SSL connections")
+
 	flag.Usage = func() {
 		os.Stderr.WriteString(usage + "\n")
 		flag.PrintDefaults()
@@ -131,7 +134,10 @@ func visit(url *url.URL) {
 	var t2 time.Time // after connect, before TLS handshake
 	if scheme == "https" {
 		t2 = time.Now()
-		c := tls.Client(conn, &tls.Config{InsecureSkipVerify: true})
+		c := tls.Client(conn, &tls.Config{
+			ServerName:         host,
+			InsecureSkipVerify: insecure,
+		})
 		if err := c.Handshake(); err != nil {
 			log.Fatalf("unable to negotiate TLS handshake: %v", err)
 		}


### PR DESCRIPTION
Fixes https://github.com/davecheney/httpstat/issues/40

Use `-k` to allow to perform insecure connection. It's same as `curl` does. 

Tested on my domain  (it's hosted on github pages)

```bash
$ httpstat https://deeeet.com
2016/09/25 12:02:40 unable to negotiate TLS handshake: x509: certificate is valid for *.github.com, github.com, *.github.io, not deeeet.com
```

```bash
$  httpstat -k https://deeeet.com

HTTP/1.1 200 OK
...
```