### PR TITLE
Add body output options

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,3 +23,5 @@ script:
   - ./httpstat -I -L http://httpbin.org/redirect/1
   - ./httpstat https://www.apple.com/
   - ./httpstat -H Accept:\ application/vnd.heroku+json\;\ version=3 https://api.heroku.com/schema
+  - ./httpstat -O http://example.com/file && stat file
+  - ./httpstat -o custom http://example.com/file && stat custom

--- a/main.go
+++ b/main.go
@@ -60,6 +60,8 @@ var (
 	onlyHeader      bool
 	insecure        bool
 	httpHeaders     headers
+	saveOutput      bool
+	outputFile      string
 
 	usage = fmt.Sprintf("usage: %s URL", os.Args[0])
 )
@@ -71,6 +73,9 @@ func init() {
 	flag.BoolVar(&onlyHeader, "I", false, "don't read body of request")
 	flag.BoolVar(&insecure, "k", false, "allow insecure SSL connections")
 	flag.Var(&httpHeaders, "H", "HTTP Header(s) to set. Can be used multiple times. -H 'Accept:...' -H 'Range:....'")
+	flag.BoolVar(&saveOutput, "O", false, "Save body as remote filename")
+	flag.StringVar(&outputFile, "o", "", "output file for body")
+
 	flag.Usage = func() {
 		os.Stderr.WriteString(usage + "\n")
 		flag.PrintDefaults()
@@ -180,8 +185,9 @@ func visit(url *url.URL) {
 	}
 
 	t5 := time.Now() // after read response
-	bodyMsg := readResponseBody(resp)
+	bodyMsg := readResponseBody(req, resp)
 	resp.Body.Close()
+
 	t6 := time.Now() // after read body
 
 	// print status line and headers
@@ -259,16 +265,42 @@ func visit(url *url.URL) {
 // readResponseBody consumes the body of the response.
 // readResponseBody returns an informational message about the
 // disposition of the response body's contents.
-func readResponseBody(resp *http.Response) string {
+func readResponseBody(req *http.Request, resp *http.Response) string {
 	// TODO(dfc) do not process body if status code is in the 30x range
 
 	// TODO(dfc) if we issued a HEAD request, there is no body to process.
 
-	if _, err := io.Copy(ioutil.Discard, resp.Body); err != nil {
+	var (
+		err     error
+		fp      io.Writer
+		bodyMsg string
+	)
+
+	if saveOutput == true || outputFile != "" {
+		var filename string
+
+		if saveOutput == true {
+			parts := strings.Split(req.URL.RequestURI(), "/")
+			filename = parts[len(parts)-1]
+		} else {
+			filename = outputFile
+		}
+
+		fp, err = os.Create(filename)
+		if err != nil {
+			log.Fatalf("unable to create file %s", outputFile)
+		}
+		bodyMsg = color.CyanString("Body read")
+	} else {
+		fp = ioutil.Discard
+		bodyMsg = color.CyanString("Body discarded")
+	}
+
+	if _, err := io.Copy(fp, resp.Body); err != nil {
 		log.Fatalf("failed to read response body: %v", err)
 	}
 
-	return color.CyanString("Body discarded")
+	return bodyMsg
 }
 
 type headers []string


### PR DESCRIPTION
Implementation for #48 

Add the -O and -o options from cURL to allow the body to be written out
to a file either as a specified name or as the name of the requested URI

Note: This will probably effect timing information because if the output options are used they will take longer than the io.Discard nop. This can instead be moved into a go routine, that is waited for at end of execution, if desired to alleviate any inconsistencies but when the move to httptrace is done I'm not sure if this will be effected.