### PR TITLE
add support for Content-Disposition header

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,3 +29,4 @@ script:
   - ./httpstat -H Accept:\ application/vnd.heroku+json\;\ version=3 https://api.heroku.com/schema
   - ./httpstat -O http://example.com/file && stat file
   - ./httpstat -o custom http://example.com/file && stat custom
+  - ./httpstat -O http://httpbin.org/response-headers?Content-Disposition=attachment%3B%20filename%3dtest.json && stat test.json

--- a/main.go
+++ b/main.go
@@ -296,13 +296,13 @@ func createBody(body string) io.Reader {
 	return strings.NewReader(body)
 }
 
-// getFilenameFromHeader tries to automatically determine the output filename,
+// getFilenameFromHeaders tries to automatically determine the output filename,
 // when saving to disk, based on the Content-Disposition header.
 // If the header is not present, or it does not contain enough information to
 // determine which filename to use, this function returns "".
-func getFilenameFromHeader(header http.Header) string {
+func getFilenameFromHeaders(headers http.Header) string {
 	// if the Content-Disposition header is set parse it
-	if hdr := header.Get("Content-Disposition"); hdr != "" {
+	if hdr := headers.Get("Content-Disposition"); hdr != "" {
 		// pull the media type, and subsequent params, from
 		// the body of the header field
 		mt, params, err := mime.ParseMediaType(hdr)
@@ -336,7 +336,7 @@ func readResponseBody(req *http.Request, resp *http.Response) string {
 		if saveOutput == true {
 			// try to get the filename from the Content-Disposition header
 			// otherwise fall back to the RequestURI
-			if filename = getFilenameFromHeader(resp.Header); filename == "" {
+			if filename = getFilenameFromHeaders(resp.Header); filename == "" {
 				filename = path.Base(req.URL.RequestURI())
 			}
 


### PR DESCRIPTION
This change adds support for reading the filename from the
`Content-Disposition` HTTP header. If the filename cannot be determined
from the `Content-Disposition` header, we fall back to using the base
path of the RequestURI.

fixes #57