### PR TITLE
Fix URL parsing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,3 +33,5 @@ script:
   - ./httpstat google.com
   - ./httpstat google.com:80
   - ./httpstat google.com:443
+  - ./httpstat golang.org:80/dl
+  - ./httpstat golang.org:443/dl

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,7 @@ install:
 script:
   - go vet $(go list ./... | grep -v "vendor")
   - go build github.com/davecheney/httpstat
+  - go test github.com/davecheney/httpstat
   - ./httpstat http://dave.cheney.net/
   - ./httpstat http://dave.cheney.net:80/
   - ./httpstat -X POST -d 'post' http://httpbin.org/post

--- a/main.go
+++ b/main.go
@@ -113,9 +113,20 @@ func main() {
 }
 
 func parseURL(uri string) *url.URL {
-	url, err := url.Parse(schemify(uri))
+	if !strings.Contains(uri, "://") && !strings.HasPrefix(uri, "//") {
+		uri = "//" + uri
+	}
+
+	url, err := url.Parse(uri)
 	if err != nil {
 		log.Fatalf("could not parse url %q: %v", uri, err)
+	}
+
+	if url.Scheme == "" {
+		url.Scheme = "http"
+		if !strings.HasSuffix(url.Host, ":80") {
+			url.Scheme += "s"
+		}
 	}
 	return url
 }
@@ -126,16 +137,6 @@ func headerKeyValue(h string) (string, string) {
 		log.Fatalf("Header '%s' has invalid format, missing ':'", h)
 	}
 	return strings.TrimRight(h[:i], " "), strings.TrimLeft(h[i:], " :")
-}
-
-func schemify(uri string) string {
-	if !strings.Contains(uri, "://") {
-		if strings.HasSuffix(uri, ":80") {
-			return "http://" + uri
-		}
-		return "https://" + uri
-	}
-	return uri
 }
 
 func getHostPort(url *url.URL) (string, string, string) {

--- a/main_test.go
+++ b/main_test.go
@@ -10,6 +10,7 @@ func TestParseURL(t *testing.T) {
 		{"https://golang.org", "https://golang.org"},
 		{"https://golang.org:443/test", "https://golang.org:443/test"},
 		{"localhost:8080/test", "https://localhost:8080/test"},
+		{"localhost:80/test", "http://localhost:80/test"},
 		{"//localhost:8080/test", "https://localhost:8080/test"},
 		{"//localhost:80/test", "http://localhost:80/test"},
 	}

--- a/main_test.go
+++ b/main_test.go
@@ -1,0 +1,23 @@
+package main
+
+import "testing"
+
+func TestParseURL(t *testing.T) {
+	tests := []struct {
+		in   string
+		want string
+	}{
+		{"https://golang.org", "https://golang.org"},
+		{"https://golang.org:443/test", "https://golang.org:443/test"},
+		{"localhost:8080/test", "https://localhost:8080/test"},
+		{"//localhost:8080/test", "https://localhost:8080/test"},
+		{"//localhost:80/test", "http://localhost:80/test"},
+	}
+
+	for _, test := range tests {
+		u := parseURL(test.in)
+		if u.String() != test.want {
+			t.Errorf("Given: %s\nwant: %s\ngot: %s", test.in, test.want, u.String())
+		}
+	}
+}


### PR DESCRIPTION
Get rid of schemify and let `url.Parse` do the heavy lifting.

Fixes #77 and replaces #78