### PR TITLE
Enable HTTP/2

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -7,3 +7,6 @@
 [submodule "vendor/github.com/mattn/go-isatty"]
 	path = vendor/github.com/mattn/go-isatty
 	url = https://github.com/mattn/go-isatty
+[submodule "vendor/golang.org/x/net"]
+	path = vendor/golang.org/x/net
+	url = https://go.googlesource.com/net

--- a/main.go
+++ b/main.go
@@ -9,6 +9,7 @@ import (
 	"io/ioutil"
 	"log"
 	"mime"
+	"net"
 	"net/http"
 	"net/http/httptrace"
 	"net/url"
@@ -19,7 +20,7 @@ import (
 	"strings"
 	"time"
 
-	"net"
+	"golang.org/x/net/http2"
 
 	"github.com/fatih/color"
 )
@@ -230,6 +231,10 @@ func visit(url *url.URL) {
 			ServerName:         host,
 			InsecureSkipVerify: insecure,
 		}
+
+		// Because we create a custom TLSClientConfig, we have to opt-in to HTTP/2.
+		// See https://github.com/golang/go/issues/14275
+		http2.ConfigureTransport(tr)
 	}
 
 	client := &http.Client{

--- a/main.go
+++ b/main.go
@@ -234,7 +234,10 @@ func visit(url *url.URL) {
 
 		// Because we create a custom TLSClientConfig, we have to opt-in to HTTP/2.
 		// See https://github.com/golang/go/issues/14275
-		http2.ConfigureTransport(tr)
+		err = http2.ConfigureTransport(tr)
+		if err != nil {
+			log.Fatalf("failed to prepare transport for HTTP/2: %v", err)
+		}
 	}
 
 	client := &http.Client{


### PR DESCRIPTION
Because we create a custom TLSClientConfig, we have to opt-in to HTTP/2.

Fixes #76