### PR TITLE
Add -v and release script

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,25 @@
+TARGETS = linux-386 linux-amd64 linux-arm linux-arm64 darwin-amd64 windows-386 windows-amd64
+COMMAND_NAME = httpstat
+PACKAGE_NAME = github.com/davecheney/$(COMMAND_NAME)
+LDFLAGS = -ldflags=-X=main.version=$(VERSION)
+OBJECTS = $(patsubst $(COMMAND_NAME)-windows-amd64,$(COMMAND_NAME)-windows-amd64.exe, $(patsubst $(COMMAND_NAME)-windows-386,$(COMMAND_NAME)-windows-386.exe, $(patsubst %,$(COMMAND_NAME)-%, $(TARGETS)))) 
+
+release: check-env $(OBJECTS) ## Build release binaries (requires VERSION)
+
+clean: ## Remove release binaries
+	rm $(OBJECTS)
+
+$(OBJECTS): $(wildcard *.go)
+	env GOOS=`echo $@ | cut -d'-' -f2` GOARCH=`echo $@ | cut -d'-' -f3 | cut -d'.' -f 1` go build -o $@ $(LDFLAGS) $(PACKAGE_NAME)
+
+.PHONY: help check-env
+
+check-env:
+ifndef VERSION
+	$(error VERSION is undefined)
+endif
+
+help:
+	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'
+
+.DEFAULT_GOAL := help

--- a/main.go
+++ b/main.go
@@ -64,11 +64,14 @@ var (
 	httpHeaders     headers
 	saveOutput      bool
 	outputFile      string
+	showVersion     bool
 
 	// number of redirects followed
 	redirectsFollowed int
 
 	usage = fmt.Sprintf("usage: %s URL", os.Args[0])
+
+	version = "devel" // for -v flag, updated during the release process with -ldflags -X=main.version=...
 )
 
 const maxRedirects = 10
@@ -82,6 +85,7 @@ func init() {
 	flag.Var(&httpHeaders, "H", "HTTP Header(s) to set. Can be used multiple times. -H 'Accept:...' -H 'Range:....'")
 	flag.BoolVar(&saveOutput, "O", false, "Save body as remote filename")
 	flag.StringVar(&outputFile, "o", "", "output file for body")
+	flag.BoolVar(&showVersion, "v", false, "print version number")
 
 	flag.Usage = func() {
 		os.Stderr.WriteString(usage + "\n")
@@ -99,6 +103,11 @@ func printf(format string, a ...interface{}) (n int, err error) {
 
 func main() {
 	flag.Parse()
+
+	if showVersion {
+		fmt.Println("httpstat", version)
+		os.Exit(0)
+	}
 
 	args := flag.Args()
 	if len(args) != 1 {

--- a/main.go
+++ b/main.go
@@ -14,6 +14,7 @@ import (
 	"net/url"
 	"os"
 	"path"
+	"runtime"
 	"sort"
 	"strconv"
 	"strings"
@@ -71,7 +72,7 @@ var (
 
 	usage = fmt.Sprintf("usage: %s URL", os.Args[0])
 
-	version = "devel" // for -v flag, updated during the release process with -ldflags -X=main.version=...
+	version = "devel" // for -v flag, updated during the release process with -ldflags=-X=main.version=...
 )
 
 const maxRedirects = 10
@@ -105,7 +106,7 @@ func main() {
 	flag.Parse()
 
 	if showVersion {
-		fmt.Println("httpstat", version)
+		fmt.Printf("%s %s (runtime: %s)\n", os.Args[0], version, runtime.Version())
 		os.Exit(0)
 	}
 


### PR DESCRIPTION
Updates #60

This PR adds a version flag to httpstat, `httpstat -v`.
The value reported is obtained from main.version which is overridden for
_release_ builds with the supplied Makefile.
```
$ git tag -a v1.0.0 -m 'release version 1.0.0'
$ env VERSION=1.0.0 make release
```
Then upload the release binaries to github.