### PR TITLE
use proper variable in os.Create() err log

### DIFF
--- a/main.go
+++ b/main.go
@@ -418,7 +418,7 @@ func readResponseBody(req *http.Request, resp *http.Response) string {
 
 		f, err := os.Create(filename)
 		if err != nil {
-			log.Fatalf("unable to create file %s", outputFile)
+			log.Fatalf("unable to create file %s", filename)
 		}
 		defer f.Close()
 		w = f


### PR DESCRIPTION
When doing the `log.Fatalf()` fall after failing to create a file, we
were using the wrong variable (`outputFile` instead of `filename`). This
would work as expected in some cases, but not all.

fixes #88