### PR TITLE
adding tls client certificate support

### DIFF
--- a/main.go
+++ b/main.go
@@ -59,13 +59,12 @@ var (
 	saveOutput      bool
 	outputFile      string
 	showVersion     bool
+	clientCertFile  string
 
 	// number of redirects followed
 	redirectsFollowed int
 
 	version = "devel" // for -v flag, updated during the release process with -ldflags=-X=main.version=...
-
-	clientCertFile string
 )
 
 const maxRedirects = 10
@@ -80,7 +79,7 @@ func init() {
 	flag.BoolVar(&saveOutput, "O", false, "Save body as remote filename")
 	flag.StringVar(&outputFile, "o", "", "output file for body")
 	flag.BoolVar(&showVersion, "v", false, "print version number")
-	flag.StringVar(&clientCertFile, "c", "", "client cert file for tls config")
+	flag.StringVar(&clientCertFile, "E", "", "client cert file for tls config")
 
 	flag.Usage = func() {
 		fmt.Fprintf(os.Stderr, "usage: %s URL\n", os.Args[0])


### PR DESCRIPTION
Fixes https://github.com/davecheney/httpstat/issues/94

This pull request adds support for client certificates.  To use specify a client certificate in PEM format that includes both the certificate and the private key in the same file with the "-c" flag.