### PR TITLE
Use httptrace WroteHeaders instead of WroteRequest

### DIFF
--- a/main.go
+++ b/main.go
@@ -221,7 +221,7 @@ func visit(url *url.URL) {
 
 			printf("\n%s%s\n", color.GreenString("Connected to "), color.CyanString(addr))
 		},
-		WroteRequest:         func(_ httptrace.WroteRequestInfo) { t3 = time.Now() },
+		WroteHeaders:         func() { t3 = time.Now() },
 		GotFirstResponseByte: func() { t4 = time.Now() },
 	}
 	req = req.WithContext(httptrace.WithClientTrace(context.Background(), trace))


### PR DESCRIPTION
When POSTing a large request, the TLS Handshake timings become very
skewed. Using WroteHeaders is about the best we can do for now until
httptrace adds additional hooks.