### PR TITLE
Use httptrace GotConn instead of WroteHeaders

### DIFF
--- a/main.go
+++ b/main.go
@@ -221,7 +221,7 @@ func visit(url *url.URL) {
 
 			printf("\n%s%s\n", color.GreenString("Connected to "), color.CyanString(addr))
 		},
-		WroteHeaders:         func() { t3 = time.Now() },
+		GotConn:              func(_ httptrace.GotConnInfo) { t3 = time.Now() },
 		GotFirstResponseByte: func() { t4 = time.Now() },
 	}
 	req = req.WithContext(httptrace.WithClientTrace(context.Background(), trace))


### PR DESCRIPTION
After doing some additional testing, it appears that the GotConn hook
fires after TLS has been established.  TLS Handshake time is between
ConnectDone and GotConn.