### PR TITLE
make cmd --help write to stdout

### DIFF
--- a/main.go
+++ b/main.go
@@ -63,6 +63,10 @@ var (
 
 	// number of redirects followed
 	redirectsFollowed int
+	// FlagSet
+	cmd *flag.FlagSet
+	// out Writer for usage
+	out io.Writer = os.Stdout
 
 	version = "devel" // for -v flag, updated during the release process with -ldflags=-X=main.version=...
 )
@@ -70,30 +74,32 @@ var (
 const maxRedirects = 10
 
 func init() {
-	flag.StringVar(&httpMethod, "X", "GET", "HTTP method to use")
-	flag.StringVar(&postBody, "d", "", "the body of a POST or PUT request; from file use @filename")
-	flag.BoolVar(&followRedirects, "L", false, "follow 30x redirects")
-	flag.BoolVar(&onlyHeader, "I", false, "don't read body of request")
-	flag.BoolVar(&insecure, "k", false, "allow insecure SSL connections")
-	flag.Var(&httpHeaders, "H", "set HTTP header; repeatable: -H 'Accept: ...' -H 'Range: ...'")
-	flag.BoolVar(&saveOutput, "O", false, "save body as remote filename")
-	flag.StringVar(&outputFile, "o", "", "output file for body")
-	flag.BoolVar(&showVersion, "v", false, "print version number")
-	flag.StringVar(&clientCertFile, "E", "", "client cert file for tls config")
+	cmd = flag.NewFlagSet(os.Args[0], flag.ExitOnError)
+	cmd.StringVar(&httpMethod, "X", "GET", "HTTP method to use")
+	cmd.StringVar(&postBody, "d", "", "the body of a POST or PUT request; from file use @filename")
+	cmd.BoolVar(&followRedirects, "L", false, "follow 30x redirects")
+	cmd.BoolVar(&onlyHeader, "I", false, "don't read body of request")
+	cmd.BoolVar(&insecure, "k", false, "allow insecure SSL connections")
+	cmd.Var(&httpHeaders, "H", "set HTTP header; repeatable: -H 'Accept: ...' -H 'Range: ...'")
+	cmd.BoolVar(&saveOutput, "O", false, "save body as remote filename")
+	cmd.StringVar(&outputFile, "o", "", "output file for body")
+	cmd.BoolVar(&showVersion, "v", false, "print version number")
+	cmd.StringVar(&clientCertFile, "E", "", "client cert file for tls config")
 
-	flag.Usage = usage
+	cmd.Usage = usage
 }
 
 func usage() {
-	fmt.Fprintf(os.Stderr, "Usage: %s [OPTIONS] URL\n\n", os.Args[0])
-	fmt.Fprintln(os.Stderr, "OPTIONS:")
-	flag.PrintDefaults()
-	fmt.Fprintln(os.Stderr, "")
-	fmt.Fprintln(os.Stderr, "ENVIRONMENT:")
-	fmt.Fprintln(os.Stderr, "  HTTP_PROXY    proxy for HTTP requests; complete URL or HOST[:PORT]")
-	fmt.Fprintln(os.Stderr, "                used for HTTPS requests if HTTPS_PROXY undefined")
-	fmt.Fprintln(os.Stderr, "  HTTPS_PROXY   proxy for HTTPS requests; complete URL or HOST[:PORT]")
-	fmt.Fprintln(os.Stderr, "  NO_PROXY      comma-separated list of hosts to exclude from proxy")
+	fmt.Fprintf(out, "Usage: %s [OPTIONS] URL\n\n", os.Args[0])
+	fmt.Fprintln(out, "OPTIONS:")
+	cmd.SetOutput(out)
+	cmd.PrintDefaults()
+	fmt.Fprintln(out, "")
+	fmt.Fprintln(out, "ENVIRONMENT:")
+	fmt.Fprintln(out, "  HTTP_PROXY    proxy for HTTP requests; complete URL or HOST[:PORT]")
+	fmt.Fprintln(out, "                used for HTTPS requests if HTTPS_PROXY undefined")
+	fmt.Fprintln(out, "  HTTPS_PROXY   proxy for HTTPS requests; complete URL or HOST[:PORT]")
+	fmt.Fprintln(out, "  NO_PROXY      comma-separated list of hosts to exclude from proxy")
 }
 
 func printf(format string, a ...interface{}) (n int, err error) {
@@ -105,16 +111,17 @@ func grayscale(code color.Attribute) func(string, ...interface{}) string {
 }
 
 func main() {
-	flag.Parse()
+	cmd.Parse(os.Args[1:])
 
 	if showVersion {
 		fmt.Printf("%s %s (runtime: %s)\n", os.Args[0], version, runtime.Version())
 		os.Exit(0)
 	}
 
-	args := flag.Args()
+	args := cmd.Args()
 	if len(args) != 1 {
-		flag.Usage()
+		out = os.Stderr
+		cmd.Usage()
 		os.Exit(2)
 	}
 

--- a/main.go
+++ b/main.go
@@ -74,7 +74,7 @@ var (
 const maxRedirects = 10
 
 func init() {
-	cmd = flag.NewFlagSet(os.Args[0], flag.ExitOnError)
+	cmd = flag.NewFlagSet(os.Args[0], flag.ContinueOnError)
 	cmd.StringVar(&httpMethod, "X", "GET", "HTTP method to use")
 	cmd.StringVar(&postBody, "d", "", "the body of a POST or PUT request; from file use @filename")
 	cmd.BoolVar(&followRedirects, "L", false, "follow 30x redirects")
@@ -111,7 +111,13 @@ func grayscale(code color.Attribute) func(string, ...interface{}) string {
 }
 
 func main() {
-	cmd.Parse(os.Args[1:])
+	if err := cmd.Parse(os.Args[1:]); err != nil {
+		if err == flag.ErrHelp {
+			os.Exit(0)
+		} else {
+			os.Exit(1)
+		}
+	}
 
 	if showVersion {
 		fmt.Printf("%s %s (runtime: %s)\n", os.Args[0], version, runtime.Version())

--- a/main.go
+++ b/main.go
@@ -124,8 +124,7 @@ func main() {
 		os.Exit(0)
 	}
 
-	args := cmd.Args()
-	if len(args) != 1 {
+	if cmd.NArg() != 1 {
 		out = os.Stderr
 		cmd.Usage()
 		os.Exit(2)
@@ -139,7 +138,7 @@ func main() {
 		httpMethod = "HEAD"
 	}
 
-	url := parseURL(args[0])
+	url := parseURL(cmd.Arg(0))
 
 	visit(url)
 }


### PR DESCRIPTION
`httpstat --help` writes to stderr, which makes output not greppable.

For example following will fail:
`httpstat --help | grep <pattern>`

From user perspective `cmd --help` , which outputs to stderr is also confusing, as there is no any indication of error.

This PR fixes this confusion.
