### PR TITLE
Selectively ignore failure to read the body

### DIFF
--- a/main.go
+++ b/main.go
@@ -446,7 +446,7 @@ func readResponseBody(req *http.Request, resp *http.Response) string {
 		msg = color.CyanString("Body read")
 	}
 
-	if _, err := io.Copy(w, resp.Body); err != nil {
+	if _, err := io.Copy(w, resp.Body); err != nil && w != ioutil.Discard {
 		log.Fatalf("failed to read response body: %v", err)
 	}
 


### PR DESCRIPTION
If we are writing the response to `/dev/null`, then why both reporting
that it failed? We can still report things like DNS latency and other
useful information.