### PR TITLE
travis: fix failing tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,20 +21,20 @@ script:
   - go vet ./...
   - go build github.com/davecheney/httpstat
   - go test github.com/davecheney/httpstat
-  - ./httpstat http://dave.cheney.net/
-  - ./httpstat http://dave.cheney.net:80/
-  - ./httpstat -X POST -d 'post' http://httpbin.org/post
-  - ./httpstat -X DELETE http://httpbin.org/delete
+  - ./httpstat https://dave.cheney.net/
+  - ./httpstat https://dave.cheney.net:443/
+  - ./httpstat -X POST -d 'post' https://httpbin.org/post
+  - ./httpstat -X DELETE https://httpbin.org/delete
   - ./httpstat https://www.google.com/
   - ./httpstat https://www.google.com:443/
-  - ./httpstat -L http://httpbin.org/redirect-to?url=https://httpbin.org/relative-redirect/1
+  - ./httpstat -L https://httpbin.org/redirect-to?url=https://httpbin.org/relative-redirect/1
   - ./httpstat -I http://example.com/
   - ./httpstat -I -L http://httpbin.org/redirect/1
   - ./httpstat https://www.apple.com/
   - ./httpstat -H Accept:\ application/vnd.heroku+json\;\ version=3 https://api.heroku.com/schema
   - ./httpstat -O http://example.com/file && stat file
   - ./httpstat -o custom http://example.com/file && stat custom
-  - ./httpstat -O http://httpbin.org/response-headers?Content-Disposition=attachment%3B%20filename%3dtest.json && stat test.json
+  - ./httpstat -O https://httpbin.org/response-headers?Content-Disposition=attachment%3B%20filename%3dtest.json && stat test.json
   - ./httpstat google.com
   - ./httpstat google.com:80
   - ./httpstat google.com:443


### PR DESCRIPTION
dave.cheney.com and httpbin have moved to HTTPS only, which trips up
httpstat if we don't use the -L flag (which we don't want to use all the
time)