### PR TITLE
Add option to specify additional CA certificates for SSL peer validation

### DIFF
--- a/main.go
+++ b/main.go
@@ -144,8 +144,11 @@ func main() {
 }
 
 // readCACerts - helper function to load additional CA certificates
-func readCACerts(certfile string) (*x509.CertPool, error) {
-	certFileBytes, err := ioutil.ReadFile(certfile)
+func readCACerts(filename string) (*x509.CertPool, error) {
+	if filename == "" {
+		return nil, nil
+	}
+	certFileBytes, err := ioutil.ReadFile(filename)
 
 	if err != nil {
 		return nil, fmt.Errorf("failed to read CA certificate file: %v", err)


### PR DESCRIPTION
Adds an option that allows the user to specify a file of one or more CA certificates that can be used for SSL peer validation. These CA certificates are added to the default pool of CA certificates that are used by Go.

Fixes #146