### PR TITLE
Use same to path and repository name

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/httpstat
+module github.com/davecheney/httpstat
 
 go 1.15
 


### PR DESCRIPTION
Without this fix, `go install` fails as following.

```bash
$ go install github.com/davecheney/httpstat@master
go: downloading github.com/davecheney/httpstat v1.0.1-0.20201227061204-995a296aed9f
go install github.com/davecheney/httpstat@master: github.com/davecheney/httpstat@none updating to
	github.com/davecheney/httpstat@v1.0.1-0.20201227061204-995a296aed9f: parsing go.mod:
	module declares its path as: github.com/httpstat
	        but was required as: github.com/davecheney/httpstat
```