### PR TITLE
Print connection SSL/TLS version

### DIFF
--- a/main.go
+++ b/main.go
@@ -272,6 +272,7 @@ func visit(url *url.URL) {
 			ServerName:         host,
 			InsecureSkipVerify: insecure,
 			Certificates:       readClientCert(clientCertFile),
+			MinVersion:         tls.VersionTLS10,
 		}
 	}
 
@@ -293,8 +294,6 @@ func visit(url *url.URL) {
 	connectedVia := "plaintext"
 	if resp.TLS != nil {
 		switch resp.TLS.Version {
-		case tls.VersionSSL30: //lint:ignore SA1019
-			connectedVia = "SSLv3"
 		case tls.VersionTLS10:
 			connectedVia = "TLSv1.0"
 		case tls.VersionTLS11:

--- a/main.go
+++ b/main.go
@@ -289,6 +289,24 @@ func visit(url *url.URL) {
 		log.Fatalf("failed to read response: %v", err)
 	}
 
+	// Print SSL/TLS version which is used for connection
+	connectedVia := "plaintext (unsecure)"
+	if resp.TLS != nil {
+		switch resp.TLS.Version {
+		case tls.VersionSSL30:
+			connectedVia = "SSLv3"
+		case tls.VersionTLS10:
+			connectedVia = "TLSv1.0"
+		case tls.VersionTLS11:
+			connectedVia = "TLSv1.1"
+		case tls.VersionTLS12:
+			connectedVia = "TLSv1.2"
+		case tls.VersionTLS13:
+			connectedVia = "TLSv1.3"
+		}
+	}
+	printf("\n%s %s\n", color.GreenString("Connected via"), color.CyanString("%s", connectedVia))
+
 	bodyMsg := readResponseBody(req, resp)
 	resp.Body.Close()
 
@@ -313,22 +331,6 @@ func visit(url *url.URL) {
 	if bodyMsg != "" {
 		printf("\n%s\n", bodyMsg)
 	}
-
-	// Print SSL/TLS version which is used for connection
-	tlsVersion := ""
-	switch resp.TLS.Version {
-	case tls.VersionSSL30:
-		tlsVersion = "SSL v3"
-	case tls.VersionTLS10:
-		tlsVersion = "TLS v1.0"
-	case tls.VersionTLS11:
-		tlsVersion = "TLS v1.1"
-	case tls.VersionTLS12:
-		tlsVersion = "TLS v1.2"
-	case tls.VersionTLS13:
-		tlsVersion = "TLS v1.3"
-	}
-	printf("\n%s %s\n", color.GreenString("Connected via"), color.CyanString("%s", tlsVersion))
 
 	fmta := func(d time.Duration) string {
 		return color.CyanString("%7dms", int(d/time.Millisecond))

--- a/main.go
+++ b/main.go
@@ -314,6 +314,22 @@ func visit(url *url.URL) {
 		printf("\n%s\n", bodyMsg)
 	}
 
+	// Print SSL/TLS version which is used for connection
+	tlsVersion := ""
+	switch resp.TLS.Version {
+	case tls.VersionSSL30:
+		tlsVersion = "SSL v3"
+	case tls.VersionTLS10:
+		tlsVersion = "TLS v1.0"
+	case tls.VersionTLS11:
+		tlsVersion = "TLS v1.1"
+	case tls.VersionTLS12:
+		tlsVersion = "TLS v1.2"
+	case tls.VersionTLS13:
+		tlsVersion = "TLS v1.3"
+	}
+	printf("\n%s %s\n", color.GreenString("Connected via"), color.CyanString("%s", tlsVersion))
+
 	fmta := func(d time.Duration) string {
 		return color.CyanString("%7dms", int(d/time.Millisecond))
 	}

--- a/main.go
+++ b/main.go
@@ -293,8 +293,7 @@ func visit(url *url.URL) {
 	connectedVia := "plaintext"
 	if resp.TLS != nil {
 		switch resp.TLS.Version {
-		//lint:ignore SA1019
-		case tls.VersionSSL30:
+		case tls.VersionSSL30: //lint:ignore SA1019
 			connectedVia = "SSLv3"
 		case tls.VersionTLS10:
 			connectedVia = "TLSv1.0"

--- a/main.go
+++ b/main.go
@@ -290,7 +290,7 @@ func visit(url *url.URL) {
 	}
 
 	// Print SSL/TLS version which is used for connection
-	connectedVia := "plaintext (unsecure)"
+	connectedVia := "plaintext"
 	if resp.TLS != nil {
 		switch resp.TLS.Version {
 		case tls.VersionSSL30:

--- a/main.go
+++ b/main.go
@@ -272,7 +272,7 @@ func visit(url *url.URL) {
 			ServerName:         host,
 			InsecureSkipVerify: insecure,
 			Certificates:       readClientCert(clientCertFile),
-			MinVersion:         tls.VersionTLS10,
+			MinVersion:         tls.VersionTLS12,
 		}
 	}
 
@@ -294,10 +294,6 @@ func visit(url *url.URL) {
 	connectedVia := "plaintext"
 	if resp.TLS != nil {
 		switch resp.TLS.Version {
-		case tls.VersionTLS10:
-			connectedVia = "TLSv1.0"
-		case tls.VersionTLS11:
-			connectedVia = "TLSv1.1"
 		case tls.VersionTLS12:
 			connectedVia = "TLSv1.2"
 		case tls.VersionTLS13:

--- a/main.go
+++ b/main.go
@@ -293,6 +293,7 @@ func visit(url *url.URL) {
 	connectedVia := "plaintext"
 	if resp.TLS != nil {
 		switch resp.TLS.Version {
+		//lint:ignore SA1019
 		case tls.VersionSSL30:
 			connectedVia = "SSLv3"
 		case tls.VersionTLS10:


### PR DESCRIPTION
Added support for printing SSL/TLS version of connection.

This is important to know, because TLSv1.3 has faster handshake than the others.