### PR TITLE
Update stinking badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,4 @@
-# httpstat [![Build Status](https://travis-ci.org/davecheney/httpstat.svg?branch=master)](https://travis-ci.org/davecheney/httpstat)
-
-[![Go Report Card](https://goreportcard.com/badge/github.com/davecheney/httpstat)](https://goreportcard.com/report/github.com/davecheney/httpstat)
+# httpstat [![Build Status](https://github.com/davecheney/httpstat/actions/workflows/push.yml/badge.svg)](https://github.com/davecheney/httpstat/actions/workflows/push.yml) [![Go Report Card](https://goreportcard.com/badge/github.com/davecheney/httpstat)](https://goreportcard.com/report/github.com/davecheney/httpstat)
 
 ![Shameless](./screenshot.png)
 


### PR DESCRIPTION
In the README, replace old Travis CI badge with Github Workflow badge
and ensure all badges are inline with the page title.