### PR TITLE
docs(readme): add Go 1.17+ install command

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,11 +9,6 @@ But seriously, https://github.com/reorx/httpstat is the new hotness, and this is
 ## Installation
 `httpstat` requires Go 1.13 or later.
 ```
-$ go get github.com/davecheney/httpstat
-```
-
-For Go 1.17+ use:
-```
 $ go install github.com/davecheney/httpstat@latest
 ```
 


### PR DESCRIPTION
### Summary

Hi @davecheney, this PR is to bring the readme up to date with Go 1.17 and only brings a small addition to the installation instructions.

### Proposed Changes

- Add new install command for Go versions 1.17+ to readme

### Reason

> Starting in Go 1.17, installing executables with go get is deprecated. go install may be used instead.

![screenshot-27082021-154923](https://user-images.githubusercontent.com/31685472/131139016-0a63c2cd-e50f-4775-a718-0d0e6881dca9.png)

Read [here](https://golang.org/doc/go-get-install-deprecation) for more info about this.

