### PR TITLE
Remove $ from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,12 +9,12 @@ But seriously, https://github.com/reorx/httpstat is the new hotness, and this is
 ## Installation
 `httpstat` requires Go 1.20 or later.
 ```
-$ go install github.com/davecheney/httpstat@latest
+go install github.com/davecheney/httpstat@latest
 ```
 
 ## Usage
 ```
-$ httpstat https://example.com/
+httpstat https://example.com/
 ```
 ## Features
 


### PR DESCRIPTION
Please let's remove the $ from the command in the README. When somebody clicks the copy button they always copy the $ which prevents copy+paste into terminal.